### PR TITLE
Only include suggestions if close to the score of the best match

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ OUTPUT_DIR = os.getenv('OUTPUT_DIR', 'output')
 ARTICLE_HISTORY_FILE = os.getenv('ARTICLE_HISTORY_FILE', "articles_history.{LANG_REGION}.csv")
 # Don't compute the embedding for a source that has less than 30 collected articles
 MINIMUM_ARTICLE_HISTORY_SIZE = os.getenv('MINIMUM_ARTICLE_HISTORY_SIZE', 30)
+SIMILARITY_CUTOFF_RATIO = os.getenv('SIMILARITY_CUTOFF_RATIO', 0.9)
 SOURCE_SIMILARITY_T10 = os.getenv('SOURCE_SIMILARITY_T10', "source_similarity_t10.{LANG_REGION}")
 SOURCE_SIMILARITY_T10_HR = os.getenv('SOURCE_SIMILARITY_T10_HR', "source_similarity_t10_hr.{LANG_REGION}")
 


### PR DESCRIPTION
This is ensuring that we are not forcing each source to necessarily have 10 similar sources. Sometimes this does not make sense, i.e. we only have 5 sport sources, any sport source suggestions after the fifth is most likely going to be some "best effort" result, and not worth including. After this change, we will not include sources in the suggestions that are >10% below the score of the most similar source.

Practical example of the change:
**Before**
```
'Bleacher Report' : 
[{'source': 'Sports Illustrated', 'score': 0.9042082694040663},
 {'source': 'The Athletic', 'score': 0.8833855548400891},
 {'source': 'FOX Sports', 'score': 0.8703762139963597},
 {'source': 'ESPN', 'score': 0.8588139557867855},
 {'source': 'CBSSports', 'score': 0.8188973647202353},
 {'source': 'FOX News', 'score': 0.7686987785102797},
 {'source': 'TMZ', 'score': 0.7635494130783808},
 {'source': 'The Independent', 'score': 0.7533171656948314},
 {'source': 'Rolling Stone', 'score': 0.7234792124570952},
 {'source': 'Dailywire', 'score': 0.7224654131927485}]
```

**After**
```
'Bleacher Report' : 
[{'source': 'Sports Illustrated', 'score': 0.9042082694040663},
 {'source': 'The Athletic', 'score': 0.8833855548400891},
 {'source': 'FOX Sports', 'score': 0.8703762139963597},
 {'source': 'ESPN', 'score': 0.8588139557867855},
 {'source': 'CBSSports', 'score': 0.8188973647202353}]
```

As a side effect, some sources might end up having only one suggestion associated with them. 